### PR TITLE
Implement the accelerometer test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ conda activate xcub-sensors-check-env
 
 Then, install the required packages with
 ```bash
-conda install -c conda-forge bipedal-locomotion-framework resolve-robotics-uri-py h5py matplotlib
+conda install -c conda-forge bipedal-locomotion-framework resolve-robotics-uri-py h5py matplotlib scipy
 ```
 
 ## 📝 Usage
@@ -28,6 +28,7 @@ python -m xcub_sensors_check --config <path_to_config_file> -o output
 The configuration file is required to configure the tests to be performed. Currently the following tests are available:
 - `OrientationTest`: checks the orientation of a sensor with respect to a frame. The test is performed by comparing the mean and the standard deviation of the orientation of the sensor with respect to the frame with the expected values. The test is passed if the mean and the standard deviation of the error are below the specified thresholds.
 - `GyroTest`: checks the angular velocity of a sensor with respect to a frame. The test is performed by comparing the mean and the standard deviation of the angular velocity of the sensor with respect to the frame with the expected values. The test is passed if the mean and the standard deviation of the error are below the specified thresholds.
+- `AccTest`: checks the linear acceleration of a sensor with respect to a frame. The test is performed by comparing the mean and the standard deviation of the linear acceleration of the sensor with respect to the frame with the expected values. The test is passed if the mean and the standard deviation of the error are below the specified thresholds.
 
 The follow example shows how to configure the tests 4 tests for the ergoCubSN000 robot. In detail we are checking the orientation of the front and rear feet and the angular velocity of the front and rear feet.
 
@@ -44,54 +45,49 @@ Then for each test a set of parameters must be specified:
 - `error_std_tolerance`: the tolerance on the standard deviation of the error. The test is passed if the standard deviation of the error is below the specified threshold.
 
 ```toml
-test_list = ["R_FOOT_FRONT_ORIENTATION", "R_FOOT_REAR_ORIENTATION", "R_FOOT_FRONT_GYRO", "R_FOOT_REAR_GYRO"]
+test_list = ["L_FOOT_FRONT_ORIENTATION", "L_FOOT_FRONT_GYRO", "L_FOOT_FRONT_ACC"]
 
 model_package_path = "package://ergoCub/robots/ergoCubSN000/model.urdf"
-dataset_path = "dataset.mat"
+dataset_path = "robot_logger_device_2023_10_16_11_39_22.mat"
+compute_joint_velocity_from_position = true
+compute_joint_acceleration_from_position = true
+velocity_svg_window_length = 31
+acceleration_svg_window_length = 31
 
-[R_FOOT_FRONT_ORIENTATION]
+[L_FOOT_FRONT_ORIENTATION]
 type = "OrientationTest"
-sensor_name = "r_foot_front_ft_eul"
-frame_name = "r_foot_front_ft"
+sensor_name = "l_foot_front_ft_eul"
+frame_name = "l_foot_front_ft"
 error_mean_tolerance = [0.1, 0.1, 0.1]
 error_std_tolerance = [0.1, 0.1, 0.1]
 
-[R_FOOT_REAR_ORIENTATION]
-type = "OrientationTest"
-sensor_name = "r_foot_rear_ft_eul"
-frame_name = "r_foot_rear_ft"
-error_mean_tolerance = [0.1, 0.1, 0.1]
-error_std_tolerance = [0.1, 0.1, 0.1]
-
-[R_FOOT_FRONT_GYRO]
+[L_FOOT_FRONT_GYRO]
 type = "GyroTest"
-sensor_name = "r_foot_front_ft_gyro"
-frame_name = "r_foot_front_ft"
+sensor_name = "l_foot_front_ft_gyro"
+frame_name = "l_foot_front_ft"
 error_mean_tolerance = [0.1, 0.1, 0.1]
 error_std_tolerance = [0.1, 0.1, 0.1]
 
-[R_FOOT_REAR_GYRO]
-type = "GyroTest"
-sensor_name = "r_foot_rear_ft_gyro"
-frame_name = "r_foot_rear_ft"
-error_mean_tolerance = [0.1, 0.1, 0.1]
-error_std_tolerance = [0.1, 0.1, 0.1]
+[L_FOOT_FRONT_ACC]
+type = "AccTest"
+sensor_name = "l_foot_front_ft_acc"
+frame_name = "l_foot_front_ft"
+error_mean_tolerance = [0.5, 0.5, 0.5]
+error_std_tolerance = [0.5, 0.5, 0.5]
 ```
 
 ## 📊 Output
 This a sample output of the application:
 ```
-🧪 Running 4 tests...
-├── Running test R_FOOT_FRONT_ORIENTATION...
-├── Running test R_FOOT_REAR_ORIENTATION...
-├── Running test R_FOOT_FRONT_GYRO...
-└── Running test R_FOOT_REAR_GYRO...
+🧪 Running 3 tests...
+├── Running test L_FOOT_FRONT_ORIENTATION...
+├── Running test L_FOOT_FRONT_GYRO...
+└── Running test L_FOOT_FRONT_ACC...
 
 📊 Test outcomes:
-├── 🔴 Test R_FOOT_FRONT_ORIENTATION: Failed
-├── 🟢 Test R_FOOT_REAR_ORIENTATION: Passed
-├── 🟢 Test R_FOOT_FRONT_GYRO: Passed
-└── 🟢 Test R_FOOT_REAR_GYRO: Passed
+├── 🔴 Test L_FOOT_FRONT_ORIENTATION: Failed
+├── 🟢 Test L_FOOT_FRONT_GYRO: Passed
+└── 🟢 Test L_FOOT_FRONT_ACC: Passed
 ```
 Further details related to each test can be found in the `output` folder.
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -27,10 +27,50 @@ def generate_test_list(config_file: Path, output_folder: Path):
     )
     dataset_relative_path = param_handler.get_parameter_string("dataset_path")
 
+    compute_joint_velocity_from_position = param_handler.get_parameter_bool(
+        "compute_joint_velocity_from_position"
+    )
+    compute_joint_acceleration_from_position = param_handler.get_parameter_bool(
+        "compute_joint_acceleration_from_position"
+    )
+
+    velocity_window_length = 0
+    if compute_joint_velocity_from_position:
+        velocity_window_length = param_handler.get_parameter_int(
+            "velocity_svg_window_length"
+        )
+
+        blf.log().info(
+            f"Computing joint velocity from position using a window length of {velocity_window_length}"
+        )
+
+    acceleration_window_length = 0
+    if compute_joint_acceleration_from_position:
+        acceleration_window_length = param_handler.get_parameter_int(
+            "acceleration_svg_window_length"
+        )
+        blf.log().info(
+            f"Computing joint acceleration from position using a window length of {acceleration_window_length}"
+        )
+
     for test_name in tests_name_list:
         test_group = param_handler.get_group(test_name)
         test_group.set_parameter_string("model_path", str(model_absolute_path))
         test_group.set_parameter_string("dataset_file_name", dataset_relative_path)
+        test_group.set_parameter_bool(
+            "compute_joint_velocity_from_position", compute_joint_velocity_from_position
+        )
+        test_group.set_parameter_int(
+            "velocity_svg_window_length", velocity_window_length
+        )
+        test_group.set_parameter_bool(
+            "compute_joint_acceleration_from_position",
+            compute_joint_acceleration_from_position,
+        )
+        test_group.set_parameter_int(
+            "acceleration_svg_window_length", acceleration_window_length
+        )
+
         test_type = getattr(xcub_sensor_check, test_group.get_parameter_string("type"))
         test = test_type(test_name, output_folder)
 

--- a/xcub_sensor_check/IMU_test.py
+++ b/xcub_sensor_check/IMU_test.py
@@ -202,10 +202,12 @@ class GyroTest(GenericImuSignalTest):
         fig.set_size_inches(10.5, 6.5)
 
         for i in range(3):
-            axs[i][0].set(ylabel="ω" + axis_name[i] + " (rad/s)")
-            axs[i][0].plot(self.expected_imu_signal[:, i], label="Kinematics")
-            axs[i][0].plot(self.imu_signal[:, i], label="Sensor")
-            axs[i][1].plot(error[:, i], label="Error")
+            axs[i][0].set(ylabel="ω${}_{" + axis_name[i] + "}$ (deg/s)")
+            axs[i][0].plot(
+                np.rad2deg(self.expected_imu_signal[:, i]), label="Kinematics"
+            )
+            axs[i][0].plot(np.rad2deg(self.imu_signal[:, i]), label="Sensor")
+            axs[i][1].plot(np.rad2deg(error[:, i]), label="Error")
             axs[i][0].legend()
             axs[i][1].legend()
 
@@ -327,7 +329,7 @@ class OrientationTest(GenericImuSignalTest):
 
         # Plot the results
         for i in range(3):
-            axs[i][0].set(ylabel="θ" + axis_name[i] + " (deg)")
+            axs[i][0].set(ylabel="θ${}_{" + axis_name[i] + "}$ (deg)")
             axs[i][0].plot(
                 np.rad2deg(self.expected_imu_signal[:, i]), label="Kinematics"
             )
@@ -413,7 +415,7 @@ class AccTest(GenericImuSignalTest):
         fig.set_size_inches(10.5, 6.5)
 
         for i in range(3):
-            axs[i][0].set(ylabel="x" + axis_name[i] + " (m/s^2)")
+            axs[i][0].set(ylabel="α${}^g_{" + axis_name[i] + "}$ (m/s${}^2$)")
             axs[i][0].plot(self.expected_imu_signal[:, i], label="Kinematics")
             axs[i][0].plot(self.imu_signal[:, i], label="Sensor")
             axs[i][1].plot(error[:, i], label="Error")

--- a/xcub_sensor_check/IMU_test.py
+++ b/xcub_sensor_check/IMU_test.py
@@ -6,6 +6,7 @@ from enum import Enum
 import idyntree.bindings as idyn
 from pathlib import Path
 import matplotlib.pyplot as plt
+from scipy.signal import savgol_filter
 
 
 class SignalType(Enum):
@@ -77,23 +78,77 @@ class GenericImuSignalTest(GenericTest):
             base_link_orientation_rpy_rad[2],
         )
 
+        compute_joint_velocity_from_position = param_handler.get_parameter_bool(
+            "compute_joint_velocity_from_position"
+        )
+        compute_joint_acceleration_from_position = param_handler.get_parameter_bool(
+            "compute_joint_acceleration_from_position"
+        )
+
+        velocity_window_length = 0
+        if compute_joint_velocity_from_position:
+            velocity_window_length = param_handler.get_parameter_int(
+                "velocity_svg_window_length"
+            )
+
+        acceleration_window_length = 0
+        if compute_joint_acceleration_from_position:
+            acceleration_window_length = param_handler.get_parameter_int(
+                "acceleration_svg_window_length"
+            )
+
         self.file_name = param_handler.get_parameter_string("dataset_file_name")
+
         with h5py.File(self.file_name, "r") as file:
             root_variable = file.get("robot_logger_device")
             joint_ref = root_variable["description_list"]
+
             self.joints_name = [
                 "".join(chr(c[0]) for c in file[ref]) for ref in joint_ref[0]
             ]
+
             self.joint_state.positions = np.squeeze(
                 np.array(root_variable["joints_state"]["positions"]["data"])
             )
 
-            self.joint_state.velocities = np.squeeze(
-                np.array(root_variable["joints_state"]["velocities"]["data"])
+            sampling_time = np.average(
+                np.diff(
+                    np.squeeze(
+                        np.array(
+                            root_variable["joints_state"]["positions"]["timestamps"]
+                        )
+                    )
+                )
             )
-            self.joint_state.accelerations = np.squeeze(
-                np.array(root_variable["joints_state"]["accelerations"]["data"])
-            )
+
+            if compute_joint_velocity_from_position:
+                self.joint_state.velocities = (
+                    savgol_filter(
+                        x=self.joint_state.positions,
+                        window_length=velocity_window_length,
+                        polyorder=3,
+                        axis=0,
+                        deriv=1,
+                    )
+                    / sampling_time
+                )
+            else:
+                self.joint_state.velocities = np.squeeze(
+                    np.array(root_variable["joints_state"]["velocities"]["data"])
+                )
+
+            if compute_joint_acceleration_from_position:
+                self.joint_state.accelerations = savgol_filter(
+                    x=self.joint_state.positions,
+                    window_length=acceleration_window_length,
+                    polyorder=3,
+                    axis=0,
+                    deriv=2,
+                ) / (sampling_time**2)
+            else:
+                self.joint_state.accelerations = np.squeeze(
+                    np.array(root_variable["joints_state"]["accelerations"]["data"])
+                )
 
         self.expected_imu_signal.resize((self.joint_state.positions.shape[0], 3))
 
@@ -293,6 +348,74 @@ class OrientationTest(GenericImuSignalTest):
         mean = np.mean(error, axis=0)
 
         # Check if the error is within the accepted tolerance
+        return (np.abs(mean) < self.accepted_mean_error).all() and (
+            std < self.accepted_std_error
+        ).all()
+
+
+class AccTest(GenericImuSignalTest):
+    def __init__(self, name: str, additional_output_folder: Path):
+        super().__init__(
+            name=name,
+            additional_output_folder=additional_output_folder,
+            signal_type=SignalType.accelerometer,
+        )
+
+    def run(self):
+        kindyn = self.get_kindyn()
+        gravity = np.array([0, 0, -blf.math.StandardAccelerationOfGravitation])
+
+        I_T_base = idyn.Transform(self.base_link_orientation, idyn.Position.Zero())
+        base_velocity = idyn.Twist.Zero()
+        base_acceleration = idyn.Vector6()
+        base_acceleration.zero()
+        base_acceleration[2] = blf.math.StandardAccelerationOfGravitation
+
+        with h5py.File(self.file_name, "r") as file:
+            root_variable = file.get("robot_logger_device")
+            self.imu_signal = np.squeeze(
+                np.array(root_variable[str(self.signal_type)][self.sensor_name]["data"])
+            )
+
+        for i in range(self.joint_state.positions.shape[0]):
+            kindyn.setRobotState(
+                I_T_base,
+                self.joint_state.positions[i, :],
+                base_velocity,
+                self.joint_state.velocities[i, :],
+                gravity,
+            )
+
+            tmp = kindyn.getFrameAcc(
+                self.frame_name, base_acceleration, self.joint_state.accelerations[i, :]
+            ).toNumPy()
+            self.expected_imu_signal[i, :] = tmp[:3]
+
+        error = self.expected_imu_signal - self.imu_signal
+
+        fig, axs = plt.subplots(3, 2)
+        axis_name = ["x", "y", "z"]
+        fig.suptitle(self.name.replace("_", " "), fontsize=16)
+        fig.set_size_inches(10.5, 6.5)
+
+        for i in range(3):
+            axs[i][0].set(ylabel="x" + axis_name[i] + " (m/s^2)")
+            axs[i][0].plot(self.expected_imu_signal[:, i], label="Kinematics")
+            axs[i][0].plot(self.imu_signal[:, i], label="Sensor")
+            axs[i][1].plot(error[:, i], label="Error")
+            axs[i][0].legend()
+            axs[i][1].legend()
+
+        (self.additional_output_folder / self.name).mkdir(parents=True, exist_ok=True)
+
+        plt.savefig(
+            str(self.additional_output_folder / self.name / (self.name + ".png"))
+        )
+        plt.close()
+
+        std = np.std(error, axis=0)
+        mean = np.mean(error, axis=0)
+
         return (np.abs(mean) < self.accepted_mean_error).all() and (
             std < self.accepted_std_error
         ).all()

--- a/xcub_sensor_check/IMU_test.py
+++ b/xcub_sensor_check/IMU_test.py
@@ -369,9 +369,18 @@ class AccTest(GenericImuSignalTest):
 
         I_T_base = idyn.Transform(self.base_link_orientation, idyn.Position.Zero())
         base_velocity = idyn.Twist.Zero()
-        base_acceleration = idyn.Vector6()
+
+        # Here we assume that the x coordinate of inertial frame is
+        # aligned to the gravity vector
+        base_acceleration = idyn.SpatialAcc()
         base_acceleration.zero()
-        base_acceleration[2] = blf.math.StandardAccelerationOfGravitation
+        base_acceleration[2] = +blf.math.StandardAccelerationOfGravitation
+
+        # Then we apply the adjoint transformation to obtain the acceleration
+        # expressed in the base frame.
+        # Please check Table 2.2 of PhD thesis of Silvio Traversaro for more details
+        # https://traversaro.github.io/traversaro-phd-thesis/traversaro-phd-thesis.pdf
+        base_acceleration = (I_T_base.inverse() * base_acceleration).toNumPy()
 
         with h5py.File(self.file_name, "r") as file:
             root_variable = file.get("robot_logger_device")

--- a/xcub_sensor_check/__init__.py
+++ b/xcub_sensor_check/__init__.py
@@ -1,1 +1,1 @@
-from xcub_sensor_check.IMU_test import GyroTest, OrientationTest
+from xcub_sensor_check.IMU_test import GyroTest, OrientationTest, AccTest


### PR DESCRIPTION
This PR implements the accelerometer test. Similar to the other tests, I assessed the expected sensor's proper acceleration linear acceleration and compared it with the data obtained from the sensor.
In more detail, I calculated the proper acceleration as follows:

```math
\alpha_{A,S} = {}^{S} \dot{V} _{A,S} - \begin{bmatrix} {}^S v _{A,S} \times {}^S \omega _{A,S} \\ 0 \end{bmatrix}
```
where $S$ represents the sensor frame, and $A$ represents the inertial frame.

To account for gravity, which is measured by the accelerometer, I set a nonzero acceleration in the `getFrameAcc` function as follows:

```math
{}^{B} \dot{V} _{A,B} = {}^B X _{A} \begin{bmatrix} 0 & 0 & +9.81 & 0 & 0 & 0 \end{bmatrix} ^\top
```

Furthermore, I have added the option to use the Savitzky-Golay filter for computing joint velocity and acceleration.